### PR TITLE
Implementation for Maven SCM URL format

### DIFF
--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -190,7 +190,7 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 		return null;
 	}
 
-	private String computeRepositoryId(String id) {
+	public static String computeRepositoryId(String id) {
 		if(id.startsWith("scm:git:https://github.com/"))
 			id =  id.substring("scm:git:https://github.com/".length());
 		else if(id.startsWith("scm:git:http://github.com/"))

--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -196,7 +196,7 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 	 * @see <a href="https://maven.apache.org/scm/scm-url-format.html">SCM URL Format</a>
 	 */
 	private static final Pattern REPOSITORY_PATTERN = Pattern.compile(
-			"^(scm:git[:|])" +								//Maven prefix for git SCM
+			"^(scm:git[:|])?" +								//Maven prefix for git SCM
 			"(https?://github\\.com/|git@github\\.com:)" +	//GitHub prefix for HTTP/HTTPS/SSH/Subversion scheme
 			"([^/]+/[^/]*?)" +								//Repository ID
 			"(\\.git)?$"									//Optional suffix ".git"

--- a/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
+++ b/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
@@ -18,15 +18,19 @@ public class UploadMojoTest {
 
 		computeRepositoryIdData.put("scm:git:https://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
 		computeRepositoryIdData.put("scm:git|https://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("https://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
 
 		computeRepositoryIdData.put("scm:git:http://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
 		computeRepositoryIdData.put("scm:git|http://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("http://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
 
 		computeRepositoryIdData.put("scm:git:git@github.com:jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
 		computeRepositoryIdData.put("scm:git|git@github.com:jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("git@github.com:jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
 
 		computeRepositoryIdData.put("scm:git:https://github.com/jutzig/github-release-plugin", "jutzig/github-release-plugin");
 		computeRepositoryIdData.put("scm:git|https://github.com/jutzig/github-release-plugin", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("https://github.com/jutzig/github-release-plugin", "jutzig/github-release-plugin");
 	}
 
 	@Test

--- a/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
+++ b/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
@@ -1,0 +1,31 @@
+package de.jutzig.github.release.plugin;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class UploadMojoTest {
+
+	private Map<String, String> computeRepositoryIdData;
+
+	@Before
+	public void setUp() throws Exception {
+		computeRepositoryIdData = new HashMap<String, String>();
+		computeRepositoryIdData.put("scm:git:https://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("scm:git:http://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("scm:git:git@github.com:jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("scm:git:https://github.com/jutzig/github-release-plugin", "jutzig/github-release-plugin");
+	}
+
+	@Test
+	public void testComputeRepositoryId() throws Exception {
+		for (String source : computeRepositoryIdData.keySet()) {
+			String expected = computeRepositoryIdData.get(source);
+			assertEquals(source, expected, UploadMojo.computeRepositoryId(source));
+		}
+	}
+}

--- a/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
+++ b/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
@@ -15,10 +15,18 @@ public class UploadMojoTest {
 	@Before
 	public void setUp() throws Exception {
 		computeRepositoryIdData = new HashMap<String, String>();
+
 		computeRepositoryIdData.put("scm:git:https://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("scm:git|https://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+
 		computeRepositoryIdData.put("scm:git:http://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("scm:git|http://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+
 		computeRepositoryIdData.put("scm:git:git@github.com:jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("scm:git|git@github.com:jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+
 		computeRepositoryIdData.put("scm:git:https://github.com/jutzig/github-release-plugin", "jutzig/github-release-plugin");
+		computeRepositoryIdData.put("scm:git|https://github.com/jutzig/github-release-plugin", "jutzig/github-release-plugin");
 	}
 
 	@Test


### PR DESCRIPTION
Maven [SCM URL Format](https://maven.apache.org/scm/scm-url-format.html) more complext than was implemented.
This pull request make complete support for SCM URL format.