### PR TITLE
Should fix #22, #23 and #24

### DIFF
--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -86,6 +86,20 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 	private String description;
 
 	/**
+	 * The commitish to use
+	 *
+	 * @parameter expression="github.commitish"
+	 */
+	private String commitish;
+
+	/**
+	 * Whether or not the release should be draft
+	 *
+	 * @parameter expression="github.draft"
+	 */
+	private Boolean draft;
+
+	/**
 	 * The github id of the project. By default initialized from the project scm connection
 	 * 
 	 * @parameter default-value="${project.scm.connection}" expression="${release.repositoryId}"
@@ -161,6 +175,10 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 				GHReleaseBuilder builder = repository.createRelease(tag);
 				if(description!=null)
 					builder.body(description);
+				if (commitish!=null)
+					builder.commitish(commitish);
+				if (draft!=null)
+					builder.draft(draft);
 				builder.prerelease(prerelease);
 				builder.name(releaseName);
 				release = builder.create();
@@ -323,7 +341,10 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 		boolean preRelease = version.endsWith("-SNAPSHOT")
 				|| StringUtils.containsIgnoreCase(version, "-alpha")
 				|| StringUtils.containsIgnoreCase(version, "-beta")
-				|| StringUtils.containsIgnoreCase(version, "-RC");
+				|| StringUtils.containsIgnoreCase(version, "-RC")
+				|| StringUtils.containsIgnoreCase(version, ".RC")
+				|| StringUtils.containsIgnoreCase(version, ".M")
+				|| StringUtils.containsIgnoreCase(version, ".BUILD_SNAPSHOT");
 		return preRelease;
 	}
 }


### PR DESCRIPTION
This will add configuration properties for specifying the `commitish` to use as well as enable to mark a release as `draft`. You can add command line properties for both like `-Dgithub.commitish=release/1.0.0` and `-Dgithub.draft=true`.

Furthermore it will add `.RC`, `.M` and `.BUILD-SNAPSHOT` as prefixes that are considered pre release