### PR TITLE
Avoid NPE when comparing release names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.49</version>
+			<version>1.85</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -47,6 +47,7 @@ import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHReleaseBuilder;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.PagedIterable;
 
 /**
  * Goal which attaches a file to a GitHub release
@@ -246,10 +247,10 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 			uploadAsset(release, asset);
 	}
 
-	private GHRelease findRelease(GHRepository repository, String releaseName2) throws IOException {
-		List<GHRelease> releases = repository.getReleases();
+	private GHRelease findRelease(GHRepository repository, String releaseNameToFind) throws IOException {
+        PagedIterable<GHRelease> releases = repository.listReleases();
 		for (GHRelease ghRelease : releases) {
-			if(ghRelease.getName().equals(releaseName2)) {
+			if (releaseNameToFind.equals(ghRelease.getName())) {
 				return ghRelease;
 			}
 		}


### PR DESCRIPTION
We have seen cases where `ghRelease.getName()` returns `null`, and thus causes a NPE. This PR fixes the problem, and updates to the latest version of the GitHub-API project.
