### PR TITLE
Issue 28: Enable overwriting releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,42 +52,36 @@
 	<build>
 		<plugins>
 			<plugin>
-				<!-- taken from http://maven.apache.org/plugin-tools/maven-plugin-plugin/examples/using-annotations.html -->
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.6.0</version>
+				<artifactId>maven-invoker-plugin</artifactId>
+				<version>3.1.0</version>
 				<configuration>
-					<!-- see http://jira.codehaus.org/browse/MNG-5346 -->
-					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+					<debug>false</debug>
+					<preBuildHookScript>clean</preBuildHookScript>
+					<postBuildHookScript>verify</postBuildHookScript>
+					<settingsFile>src/it/settings.xml</settingsFile>
+					<cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+					<addTestClassPath>true</addTestClassPath>
+					<mergeUserSettings>true</mergeUserSettings>
 				</configuration>
 				<executions>
 					<execution>
-						<id>mojo-descriptor</id>
+						<id>integration-tests-with-poms</id>
 						<goals>
-							<goal>descriptor</goal>
+							<goal>install</goal>
+							<goal>run</goal>
 						</goals>
-					</execution>
-					<!-- if you want to generate help goal -->
-					<execution>
-						<id>help-goal</id>
-						<goals>
-							<goal>helpmojo</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 
-			<plugin>
-				<groupId>org.codehaus.plexus</groupId>
-				<artifactId>plexus-component-metadata</artifactId>
-				<version>1.7.1</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>generate-metadata</goal>
-						</goals>
+						<phase>package</phase>
 					</execution>
 				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.groovy</groupId>
+						<artifactId>groovy-all</artifactId>
+						<version>2.4.5</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
 	</distributionManagement>
 
 	<properties>
+		<version.maven>3.6.0</version.maven>
+
 		<maven.compiler.source>1.6</maven.compiler.source>
 		<maven.compiler.target>1.6</maven.compiler.target>
 	</properties>
@@ -50,8 +52,47 @@
 	<build>
 		<plugins>
 			<plugin>
+				<!-- taken from http://maven.apache.org/plugin-tools/maven-plugin-plugin/examples/using-annotations.html -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.6.0</version>
+				<configuration>
+					<!-- see http://jira.codehaus.org/browse/MNG-5346 -->
+					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+				</configuration>
+				<executions>
+					<execution>
+						<id>mojo-descriptor</id>
+						<goals>
+							<goal>descriptor</goal>
+						</goals>
+					</execution>
+					<!-- if you want to generate help goal -->
+					<execution>
+						<id>help-goal</id>
+						<goals>
+							<goal>helpmojo</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-component-metadata</artifactId>
+				<version>1.7.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>generate-metadata</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.4.2</version>
+				<version>2.5.3</version>
 				<configuration>
 					<autoVersionSubmodules>true</autoVersionSubmodules>
 					<useReleaseProfile>false</useReleaseProfile>
@@ -152,16 +193,23 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.6</version>
+		</dependency>
+		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.85</version>
+			<version>1.95</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 			<version>3.1.0</version>
 			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/src/it/test-release/README.md
+++ b/src/it/test-release/README.md
@@ -1,0 +1,11 @@
+# How this works
+
+* The `maven-invoker-plugin` uses it's own `settings.xml` which is merged with the one from `~/.m2/settings.xml`.
+* The credentials for deploying toe Github are under the `~/.m2/settings.xml`, so as to not having to add them
+  as sources.
+* The `repositoryId` and expected `serverId` in the `~/.m2/settings.xml` file are as follows
+```
+        <repositoryId>jutzig/github-release-plugin</repositoryId>
+        <serverId>jutzig/github-release-plugin</serverId>
+
+```

--- a/src/it/test-release/invoker.properties
+++ b/src/it/test-release/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=deploy -Dmaven.deploy.skip=true -e -X

--- a/src/it/test-release/pom.xml
+++ b/src/it/test-release/pom.xml
@@ -1,0 +1,70 @@
+<project>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>de.jutzig</groupId>
+    <artifactId>test-project</artifactId>
+    <version>@project.version@</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <scm>
+        <connection>scm:git:git@github.com:jutzig/github-release-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jutzig/github-release-plugin.git</developerConnection>
+        <url>https://github.com/jutzig/github-release-plugin/tree/${project.scm.tag}</url>
+        <tag>master</tag>
+    </scm>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+
+                <configuration>
+                    <description>Test artifact ${project.version}.</description>
+                    <releaseName>${project.version}</releaseName>
+                    <tag>${project.version}</tag>
+
+                    <overwriteArtifact>true</overwriteArtifact>
+                    <repositoryId>jutzig/github-release-plugin</repositoryId>
+                    <serverId>jutzig/github-release-plugin</serverId>
+                    <deleteRelease>true</deleteRelease>
+
+                    <fileSets>
+                        <fileSet>
+                            <directory>${project.build.directory}</directory>
+                            <includes>
+                                <include>${project.artifactId}*.jar</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>release</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/test-release/src/main/java/de/jutzig/maven/test/HelloWorld.java
+++ b/src/it/test-release/src/main/java/de/jutzig/maven/test/HelloWorld.java
@@ -1,0 +1,11 @@
+package de.jutzig.maven.test;
+
+public class HelloWorld
+{
+    
+    public static void main(String[] args)
+    {
+        System.out.println("Hello, world!");
+    }
+    
+}

--- a/src/it/test-release/src/test/java/de/jutzig/maven/test/HelloWorldTest.java
+++ b/src/it/test-release/src/test/java/de/jutzig/maven/test/HelloWorldTest.java
@@ -1,0 +1,17 @@
+package de.jutzig.maven.test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HelloWorldTest
+{
+
+	@Test
+	public void connectionTest() throws IOException
+	{
+	}
+
+}

--- a/src/it/test-release/verify.groovy
+++ b/src/it/test-release/verify.groovy
@@ -1,0 +1,2 @@
+// TODO: Add a proper check, but, basically, if the invoker build fails, that would be enough of a failure.
+return true

--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -309,7 +309,7 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 			getLog().debug("Using server credentials from system properties 'username' and 'password'");	
 			return GitHub.connectUsingPassword(usernameProperty, passwordProperty);
 		}
-			
+
 		Server server = getServer(settings, serverId);
 		if (server == null)
 			throw new MojoExecutionException(MessageFormat.format("Server ''{0}'' not found in settings", serverId));


### PR DESCRIPTION
This fixes #28.

I have added a [`maven-invoker-test`](https://github.com/carlspring/github-release-plugin/tree/issue-28/enable-overwriting-releases/src/it/test-release) and a [`README.md`](https://github.com/carlspring/github-release-plugin/blob/issue-28/enable-overwriting-releases/src/it/test-release/README.md).

@jutzig , would you mind having a look and merging this? If you approve it, when do you think we could have a new release? :)
