### PR TITLE
Fix #16: Added support for GitHub Enterprise instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Additional Parameters:
 
  * `-Dgithub.draft=true` creates the release in draft state
  * `-Dgithub.commitish=release/1.0.0` allows to specify a commitsh
- * `-Dgithub.apiEndpoint=https://github.myorg.com/` allows to customize the root endpoint of GitHub REST API in case of private GitHub Enterprise installations.
 
 The plugin is available on Maven central
+
+## Note on the GitHub API endpoints
+The endpoint for GitHub API is inferred from `<scm>` connection string. When missing, it by default would use the public endpoint at https://api.github.com.
+If you want to upload to a GitHub enterprise instance, then a respective `<scm>` connection string must be specified.

--- a/README.md
+++ b/README.md
@@ -54,5 +54,6 @@ Additional Parameters:
 
  * `-Dgithub.draft=true` creates the release in draft state
  * `-Dgithub.commitish=release/1.0.0` allows to specify a commitsh
+ * `-Dgithub.apiEndpoint=https://github.myorg.com/` allows to customize the root endpoint of GitHub REST API in case of private GitHub Enterprise installations.
 
 The plugin is available on Maven central

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.95</version>
+			<version>1.317</version>
 		</dependency>
 
 		<dependency>
@@ -221,6 +221,11 @@
 			<artifactId>maven-core</artifactId>
 			<version>3.5.4</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>3.2.1</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
 	<properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.7</java.version>
+		<java.version>1.8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 	</properties>
@@ -229,9 +229,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.10.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -301,14 +301,14 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 		if (!matcher.matches()) {
 			return PUBLIC_GITUHB_API_ENDPOINT;
 		}
-
 		String githubApiEndpoint = matcher.group(2);
+		if (githubApiEndpoint.contains("github.com")) {
+			return PUBLIC_GITUHB_API_ENDPOINT;
+		}
+
 		if (githubApiEndpoint.startsWith("git@")) {
 			// According to the regex pattern above, the matched group would be in a form of git@hostname:
 			githubApiEndpoint = githubApiEndpoint.substring(4, githubApiEndpoint.length() - 1);
-		}
-		if (githubApiEndpoint.contains("github.com")) {
-			return PUBLIC_GITUHB_API_ENDPOINT;
 		}
 
 		githubApiEndpoint = StringUtils.removeEnd(githubApiEndpoint, "/");

--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -298,9 +298,9 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 			return PUBLIC_GITUHB_API_ENDPOINT;
 		}
 		Matcher matcher = REPOSITORY_PATTERN.matcher(scm.getConnection());
-        if (!matcher.matches()) {
-            return PUBLIC_GITUHB_API_ENDPOINT;
-        }
+		if (!matcher.matches()) {
+			return PUBLIC_GITUHB_API_ENDPOINT;
+		}
 
 		String githubApiEndpoint = matcher.group(2);
 		if (githubApiEndpoint.startsWith("git@")) {

--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -48,6 +48,7 @@ import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHReleaseBuilder;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.PagedIterable;
 
 /**
@@ -91,6 +92,12 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 	 */
 	@Parameter(property = "github.draft")
 	private Boolean draft;
+
+	/**
+	 * GitHub REST API root endpoint.
+	 */
+	@Parameter(property = "github.apiEndpoint", defaultValue = "https://api.github.com")
+	private String githubApiEndpoint;
 
 	/**
 	 * The github id of the project. By default initialized from the project scm connection
@@ -311,10 +318,11 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 		String serverUsername = server.getUsername();
 		String serverPassword = server.getPassword();
 		String serverAccessToken = server.getPrivateKey();
+		GitHubBuilder gitHubBuilder = new GitHubBuilder().withEndpoint(githubApiEndpoint);
 		if (StringUtils.isNotEmpty(serverUsername) && StringUtils.isNotEmpty(serverPassword))
-			return GitHub.connectUsingPassword(serverUsername, serverPassword);
+			return gitHubBuilder.withPassword(serverUsername, serverPassword).build();
 		else if (StringUtils.isNotEmpty(serverAccessToken))
-			return GitHub.connectUsingOAuth(serverAccessToken);
+			return gitHubBuilder.withOAuthToken(serverAccessToken).build();
 		else
 			throw new MojoExecutionException("Configuration for server " + serverId + " has no login credentials");
 	}

--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -295,10 +295,11 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 	public GitHub createGithub(String serverId) throws MojoExecutionException, IOException {
 		String usernameProperty = System.getProperty("username");
 		String passwordProperty = System.getProperty("password");
+		GitHubBuilder gitHubBuilder = new GitHubBuilder().withEndpoint(githubApiEndpoint);
 		if(usernameProperty!=null && passwordProperty!=null)
 		{
-			getLog().debug("Using server credentials from system properties 'username' and 'password'");	
-			return GitHub.connectUsingPassword(usernameProperty, passwordProperty);
+			getLog().debug("Using server credentials from system properties 'username' and 'password'");
+			return gitHubBuilder.withPassword(usernameProperty, passwordProperty).build();
 		}
 
 		Server server = getServer(settings, serverId);
@@ -318,7 +319,6 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 		String serverUsername = server.getUsername();
 		String serverPassword = server.getPassword();
 		String serverAccessToken = server.getPrivateKey();
-		GitHubBuilder gitHubBuilder = new GitHubBuilder().withEndpoint(githubApiEndpoint);
 		if (StringUtils.isNotEmpty(serverUsername) && StringUtils.isNotEmpty(serverPassword))
 			return gitHubBuilder.withPassword(serverUsername, serverPassword).build();
 		else if (StringUtils.isNotEmpty(serverAccessToken))

--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -25,11 +25,14 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.FileSet;
+import org.apache.maven.model.Scm;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
@@ -57,6 +60,7 @@ import org.kohsuke.github.PagedIterable;
 @Mojo(name = "release", defaultPhase = LifecyclePhase.DEPLOY)
 public class UploadMojo extends AbstractMojo implements Contextualizable{
 
+	private static final String PUBLIC_GITUHB_API_ENDPOINT = "https://api.github.com";
 	/**
 	 * Server id for github access.
 	 */
@@ -92,12 +96,6 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 	 */
 	@Parameter(property = "github.draft")
 	private Boolean draft;
-
-	/**
-	 * GitHub REST API root endpoint.
-	 */
-	@Parameter(property = "github.apiEndpoint", defaultValue = "https://api.github.com")
-	private String githubApiEndpoint;
 
 	/**
 	 * The github id of the project. By default initialized from the project scm connection
@@ -155,6 +153,9 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 	 */
 	@Parameter(defaultValue = "false")
 	private Boolean failOnExistingRelease;
+
+	@Component
+	private MavenProject project;
 
 	public void execute() throws MojoExecutionException {
 		if(releaseName==null)
@@ -277,7 +278,7 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 	 */
 	private static final Pattern REPOSITORY_PATTERN = Pattern.compile(
 			"^(scm:git[:|])?" +								//Maven prefix for git SCM
-			"(https?://github\\.com/|git@github\\.com:)" +	//GitHub prefix for HTTP/HTTPS/SSH/Subversion scheme
+			"(https?://[\\w\\d.-]+/|git@[\\w\\d.-]+:)" +	//GitHub prefix for HTTP/HTTPS/SSH/Subversion scheme
 			"([^/]+/[^/\\.]+)" +							//Repository ID
 			"(\\.git)?" +									//Optional suffix ".git"
 			"(/.*)?$"										//Optional child project path
@@ -292,9 +293,38 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 		}
 	}
 
+	static String computeGithubApiEndpoint(Scm scm) {
+		if (scm == null || StringUtils.isEmpty(scm.getConnection())) {
+			return PUBLIC_GITUHB_API_ENDPOINT;
+		}
+
+		Matcher matcher = REPOSITORY_PATTERN.matcher(scm.getConnection());
+		if (matcher.matches()) {
+			String githubApiEndpoint = matcher.group(2);
+			if (githubApiEndpoint.startsWith("git@")) {
+				// According to the regex pattern above, the matched group would be in a form of git@hostname:
+				githubApiEndpoint = githubApiEndpoint.substring(4, githubApiEndpoint.length() - 1);
+			}
+			// Public
+			if (githubApiEndpoint.contains("github.com")) {
+				return PUBLIC_GITUHB_API_ENDPOINT;
+			}
+
+			githubApiEndpoint = StringUtils.removeEnd(githubApiEndpoint, "/");
+			if (!githubApiEndpoint.startsWith("http")) {
+				githubApiEndpoint = "https://" + githubApiEndpoint;
+			}
+			// See https://docs.github.com/en/enterprise-server@3.10/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#schema
+			return githubApiEndpoint + "/api/v3";
+		} else {
+			return PUBLIC_GITUHB_API_ENDPOINT;
+		}
+	}
+
 	public GitHub createGithub(String serverId) throws MojoExecutionException, IOException {
 		String usernameProperty = System.getProperty("username");
 		String passwordProperty = System.getProperty("password");
+		String githubApiEndpoint = computeGithubApiEndpoint(project.getScm());
 		GitHubBuilder gitHubBuilder = new GitHubBuilder().withEndpoint(githubApiEndpoint);
 		if(usernameProperty!=null && passwordProperty!=null)
 		{

--- a/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
+++ b/src/main/java/de/jutzig/github/release/plugin/UploadMojo.java
@@ -297,29 +297,27 @@ public class UploadMojo extends AbstractMojo implements Contextualizable{
 		if (scm == null || StringUtils.isEmpty(scm.getConnection())) {
 			return PUBLIC_GITUHB_API_ENDPOINT;
 		}
-
 		Matcher matcher = REPOSITORY_PATTERN.matcher(scm.getConnection());
-		if (matcher.matches()) {
-			String githubApiEndpoint = matcher.group(2);
-			if (githubApiEndpoint.startsWith("git@")) {
-				// According to the regex pattern above, the matched group would be in a form of git@hostname:
-				githubApiEndpoint = githubApiEndpoint.substring(4, githubApiEndpoint.length() - 1);
-			}
-			// Public
-			if (githubApiEndpoint.contains("github.com")) {
-				return PUBLIC_GITUHB_API_ENDPOINT;
-			}
+        if (!matcher.matches()) {
+            return PUBLIC_GITUHB_API_ENDPOINT;
+        }
 
-			githubApiEndpoint = StringUtils.removeEnd(githubApiEndpoint, "/");
-			if (!githubApiEndpoint.startsWith("http")) {
-				githubApiEndpoint = "https://" + githubApiEndpoint;
-			}
-			// See https://docs.github.com/en/enterprise-server@3.10/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#schema
-			return githubApiEndpoint + "/api/v3";
-		} else {
+		String githubApiEndpoint = matcher.group(2);
+		if (githubApiEndpoint.startsWith("git@")) {
+			// According to the regex pattern above, the matched group would be in a form of git@hostname:
+			githubApiEndpoint = githubApiEndpoint.substring(4, githubApiEndpoint.length() - 1);
+		}
+		if (githubApiEndpoint.contains("github.com")) {
 			return PUBLIC_GITUHB_API_ENDPOINT;
 		}
-	}
+
+		githubApiEndpoint = StringUtils.removeEnd(githubApiEndpoint, "/");
+		if (!githubApiEndpoint.startsWith("http")) {
+			githubApiEndpoint = "https://" + githubApiEndpoint;
+		}
+		// See https://docs.github.com/en/enterprise-server@3.10/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#schema
+		return githubApiEndpoint + "/api/v3";
+    }
 
 	public GitHub createGithub(String serverId) throws MojoExecutionException, IOException {
 		String usernameProperty = System.getProperty("username");

--- a/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
+++ b/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
@@ -1,54 +1,49 @@
 package de.jutzig.github.release.plugin;
 
-import org.junit.Before;
-import org.junit.Test;
+import java.util.stream.Stream;
 
-import java.util.HashMap;
-import java.util.Map;
+import org.apache.maven.model.Scm;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class UploadMojoTest {
+class UploadMojoTest {
+	@ParameterizedTest(name = "{0} should resolve to {1} repository id")
+	@CsvSource({
+		"scm:git:https://github.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"scm:git|https://github.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"https://github.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
 
-	private Map<String, String> computeRepositoryIdData;
+		"scm:git:http://github.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"scm:git|http://github.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"http://github.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
 
-	@Before
-	public void setUp() throws Exception {
-		computeRepositoryIdData = new HashMap<String, String>();
+		"scm:git:git@github.com:jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"scm:git|git@github.com:jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"git@github.com:jutzig/github-release-plugin.git, jutzig/github-release-plugin",
 
-		computeRepositoryIdData.put("scm:git:https://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("scm:git|https://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("https://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		"scm:git:https://github.com/jutzig/github-release-plugin, jutzig/github-release-plugin",
+		"scm:git|https://github.com/jutzig/github-release-plugin, jutzig/github-release-plugin",
+		"https://github.com/jutzig/github-release-plugin, jutzig/github-release-plugin",
 
-		computeRepositoryIdData.put("scm:git:http://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("scm:git|http://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("http://github.com/jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
+		"scm:git:http://github.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin",
+		"scm:git|http://github.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin",
+		"http://github.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin"
+	})
+	void testComputeRepositoryId(String scmString, String expectedRepositoryId) {
+		assertEquals(expectedRepositoryId, UploadMojo.computeRepositoryId(scmString));
+	}
 
-		computeRepositoryIdData.put("scm:git:git@github.com:jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("scm:git|git@github.com:jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("git@github.com:jutzig/github-release-plugin.git", "jutzig/github-release-plugin");
-
-		computeRepositoryIdData.put("scm:git:https://github.com/jutzig/github-release-plugin", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("scm:git|https://github.com/jutzig/github-release-plugin", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("https://github.com/jutzig/github-release-plugin", "jutzig/github-release-plugin");
-
-		computeRepositoryIdData.put("scm:git:http://github.com/jutzig/github-release-plugin.git/child", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("scm:git|http://github.com/jutzig/github-release-plugin.git/child", "jutzig/github-release-plugin");
-		computeRepositoryIdData.put("http://github.com/jutzig/github-release-plugin.git/child", "jutzig/github-release-plugin");
+	@ParameterizedTest(name = "{0} should resolve to {1} endpoiont")
+	@MethodSource("scmFixture")
+	void testGithubEndpoint(Scm scm, String expectedEndpoint) {
+		assertEquals(expectedEndpoint, UploadMojo.computeGithubApiEndpoint(scm));
 	}
 
 	@Test
-	public void testComputeRepositoryId() throws Exception {
-		for (String source : computeRepositoryIdData.keySet()) {
-			String expected = computeRepositoryIdData.get(source);
-			assertEquals(source, expected, UploadMojo.computeRepositoryId(source));
-		}
-	}
-
-	@Test
-	public void testGuessPreRelease() {
+	void testGuessPreRelease() {
 		assertTrue(UploadMojo.guessPreRelease("1.0-SNAPSHOT"));
 		assertTrue(UploadMojo.guessPreRelease("1.0-alpha"));
 		assertTrue(UploadMojo.guessPreRelease("1.0-alpha-1"));
@@ -61,5 +56,60 @@ public class UploadMojoTest {
 
 		assertFalse(UploadMojo.guessPreRelease("1"));
 		assertFalse(UploadMojo.guessPreRelease("1.0"));
+	}
+
+	private static Stream<Arguments> scmFixture() {
+		return Stream.of(
+			// Public GitHub
+			Arguments.of(mockScmWithConnectionString("scm:git:https://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("scm:git|https://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("https://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+
+			Arguments.of(mockScmWithConnectionString("scm:git:http://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("scm:git|http://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("http://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+
+			Arguments.of(mockScmWithConnectionString("scm:git:git@github.com:jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("scm:git|git@github.com:jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("git@github.com:jutzig/github-release-plugin.git"), "https://api.github.com"),
+
+			Arguments.of(mockScmWithConnectionString("scm:git:https://github.com/jutzig/github-release-plugin"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("scm:git|https://github.com/jutzig/github-release-plugin"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("https://github.com/jutzig/github-release-plugin"), "https://api.github.com"),
+
+			Arguments.of(mockScmWithConnectionString("scm:git:http://github.com/jutzig/github-release-plugin.git/child"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("scm:git|http://github.com/jutzig/github-release-plugin.git/child"), "https://api.github.com"),
+			Arguments.of(mockScmWithConnectionString("http://github.com/jutzig/github-release-plugin.git/child"), "https://api.github.com"),
+
+			// GitHub Enterprise
+			Arguments.of(mockScmWithConnectionString("scm:git:https://github.acme.com/jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("scm:git|https://github.acme.com/jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("https://github.acme.com/jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+
+			Arguments.of(mockScmWithConnectionString("scm:git:http://github.acme.com/jutzig/github-release-plugin.git"), "http://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("scm:git|http://github.acme.com/jutzig/github-release-plugin.git"), "http://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("http://github.acme.com/jutzig/github-release-plugin.git"), "http://github.acme.com/api/v3"),
+
+			Arguments.of(mockScmWithConnectionString("scm:git:git@github.acme.com:jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("scm:git|git@github.acme.com:jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("git@github.acme.com:jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+
+			Arguments.of(mockScmWithConnectionString("scm:git:https://github.acme.com/jutzig/github-release-plugin"), "https://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("scm:git|https://github.acme.com/jutzig/github-release-plugin"), "https://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("https://github.acme.com/jutzig/github-release-plugin"), "https://github.acme.com/api/v3"),
+
+			Arguments.of(mockScmWithConnectionString("scm:git:http://github.acme.com/jutzig/github-release-plugin.git/child"), "http://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("scm:git|http://github.acme.com/jutzig/github-release-plugin.git/child"), "http://github.acme.com/api/v3"),
+			Arguments.of(mockScmWithConnectionString("http://github.acme.com/jutzig/github-release-plugin.git/child"), "http://github.acme.com/api/v3"),
+
+			// Fallback to public
+			Arguments.of(null, "https://api.github.com")
+		);
+	}
+
+	private static Scm mockScmWithConnectionString(String connection) {
+		Scm scm = new Scm();
+		scm.setConnection(connection);
+		return scm;
 	}
 }

--- a/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
+++ b/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class UploadMojoTest {
 	@ParameterizedTest(name = "{0} should resolve to {1} repository id")
 	@CsvSource({
+		// Public
 		"scm:git:https://github.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
 		"scm:git|https://github.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
 		"https://github.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
@@ -30,7 +31,28 @@ class UploadMojoTest {
 
 		"scm:git:http://github.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin",
 		"scm:git|http://github.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin",
-		"http://github.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin"
+		"http://github.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin",
+		
+		// Enterprise
+		"scm:git:https://github.acme.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"scm:git|https://github.acme.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"https://github.acme.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+
+		"scm:git:http://github.acme.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"scm:git|http://github.acme.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"http://github.acme.com/jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+
+		"scm:git:git@github.acme.com:jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"scm:git|git@github.acme.com:jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+		"git@github.acme.com:jutzig/github-release-plugin.git, jutzig/github-release-plugin",
+
+		"scm:git:https://github.acme.com/jutzig/github-release-plugin, jutzig/github-release-plugin",
+		"scm:git|https://github.acme.com/jutzig/github-release-plugin, jutzig/github-release-plugin",
+		"https://github.acme.com/jutzig/github-release-plugin, jutzig/github-release-plugin",
+
+		"scm:git:http://github.acme.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin",
+		"scm:git|http://github.acme.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin",
+		"http://github.acme.com/jutzig/github-release-plugin.git/child, jutzig/github-release-plugin"
 	})
 	void testComputeRepositoryId(String scmString, String expectedRepositoryId) {
 		assertEquals(expectedRepositoryId, UploadMojo.computeRepositoryId(scmString));

--- a/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
+++ b/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
@@ -58,7 +58,7 @@ class UploadMojoTest {
 		assertEquals(expectedRepositoryId, UploadMojo.computeRepositoryId(scmString));
 	}
 
-	@ParameterizedTest(name = "{0} should resolve to {1} endpoiont")
+	@ParameterizedTest(name = "{0} should resolve to {1} endpoint")
 	@MethodSource("scmFixture")
 	void testGithubEndpoint(Scm scm, String expectedEndpoint) {
 		assertEquals(expectedEndpoint, UploadMojo.computeGithubApiEndpoint(scm));

--- a/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
+++ b/src/test/java/de/jutzig/github/release/plugin/UploadMojoTest.java
@@ -83,53 +83,53 @@ class UploadMojoTest {
 	private static Stream<Arguments> scmFixture() {
 		return Stream.of(
 			// Public GitHub
-			Arguments.of(mockScmWithConnectionString("scm:git:https://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("scm:git|https://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("https://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git:https://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git|https://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("https://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
 
-			Arguments.of(mockScmWithConnectionString("scm:git:http://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("scm:git|http://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("http://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git:http://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git|http://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("http://github.com/jutzig/github-release-plugin.git"), "https://api.github.com"),
 
-			Arguments.of(mockScmWithConnectionString("scm:git:git@github.com:jutzig/github-release-plugin.git"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("scm:git|git@github.com:jutzig/github-release-plugin.git"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("git@github.com:jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git:git@github.com:jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git|git@github.com:jutzig/github-release-plugin.git"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("git@github.com:jutzig/github-release-plugin.git"), "https://api.github.com"),
 
-			Arguments.of(mockScmWithConnectionString("scm:git:https://github.com/jutzig/github-release-plugin"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("scm:git|https://github.com/jutzig/github-release-plugin"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("https://github.com/jutzig/github-release-plugin"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git:https://github.com/jutzig/github-release-plugin"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git|https://github.com/jutzig/github-release-plugin"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("https://github.com/jutzig/github-release-plugin"), "https://api.github.com"),
 
-			Arguments.of(mockScmWithConnectionString("scm:git:http://github.com/jutzig/github-release-plugin.git/child"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("scm:git|http://github.com/jutzig/github-release-plugin.git/child"), "https://api.github.com"),
-			Arguments.of(mockScmWithConnectionString("http://github.com/jutzig/github-release-plugin.git/child"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git:http://github.com/jutzig/github-release-plugin.git/child"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("scm:git|http://github.com/jutzig/github-release-plugin.git/child"), "https://api.github.com"),
+			Arguments.of(scmWithConnectionString("http://github.com/jutzig/github-release-plugin.git/child"), "https://api.github.com"),
 
 			// GitHub Enterprise
-			Arguments.of(mockScmWithConnectionString("scm:git:https://github.acme.com/jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("scm:git|https://github.acme.com/jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("https://github.acme.com/jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git:https://github.acme.com/jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git|https://github.acme.com/jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("https://github.acme.com/jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
 
-			Arguments.of(mockScmWithConnectionString("scm:git:http://github.acme.com/jutzig/github-release-plugin.git"), "http://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("scm:git|http://github.acme.com/jutzig/github-release-plugin.git"), "http://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("http://github.acme.com/jutzig/github-release-plugin.git"), "http://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git:http://github.acme.com/jutzig/github-release-plugin.git"), "http://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git|http://github.acme.com/jutzig/github-release-plugin.git"), "http://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("http://github.acme.com/jutzig/github-release-plugin.git"), "http://github.acme.com/api/v3"),
 
-			Arguments.of(mockScmWithConnectionString("scm:git:git@github.acme.com:jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("scm:git|git@github.acme.com:jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("git@github.acme.com:jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git:git@github.acme.com:jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git|git@github.acme.com:jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("git@github.acme.com:jutzig/github-release-plugin.git"), "https://github.acme.com/api/v3"),
 
-			Arguments.of(mockScmWithConnectionString("scm:git:https://github.acme.com/jutzig/github-release-plugin"), "https://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("scm:git|https://github.acme.com/jutzig/github-release-plugin"), "https://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("https://github.acme.com/jutzig/github-release-plugin"), "https://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git:https://github.acme.com/jutzig/github-release-plugin"), "https://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git|https://github.acme.com/jutzig/github-release-plugin"), "https://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("https://github.acme.com/jutzig/github-release-plugin"), "https://github.acme.com/api/v3"),
 
-			Arguments.of(mockScmWithConnectionString("scm:git:http://github.acme.com/jutzig/github-release-plugin.git/child"), "http://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("scm:git|http://github.acme.com/jutzig/github-release-plugin.git/child"), "http://github.acme.com/api/v3"),
-			Arguments.of(mockScmWithConnectionString("http://github.acme.com/jutzig/github-release-plugin.git/child"), "http://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git:http://github.acme.com/jutzig/github-release-plugin.git/child"), "http://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("scm:git|http://github.acme.com/jutzig/github-release-plugin.git/child"), "http://github.acme.com/api/v3"),
+			Arguments.of(scmWithConnectionString("http://github.acme.com/jutzig/github-release-plugin.git/child"), "http://github.acme.com/api/v3"),
 
 			// Fallback to public
 			Arguments.of(null, "https://api.github.com")
 		);
 	}
 
-	private static Scm mockScmWithConnectionString(String connection) {
+	private static Scm scmWithConnectionString(String connection) {
 		Scm scm = new Scm();
 		scm.setConnection(connection);
 		return scm;


### PR DESCRIPTION
This RP adds support for customizing the GitHub API endpoint. This is needed if we want to publish releases to GitHub Enterprise instances hosted inside organizations.

The endpoint is inferred based on the `<scm>` connection string and falls back to a regular public one (https://api.github.com).

It should resolve #16.